### PR TITLE
Add `sampling` module with code to sample categories using propensities

### DIFF
--- a/src/vivarium_helpers/prob_distributions/fit.py
+++ b/src/vivarium_helpers/prob_distributions/fit.py
@@ -34,6 +34,24 @@ def l2_relative_error_loss(measured_val, true_val):
     return (((measured_val - true_val) /
         np.maximum(np.abs(true_val), 1e-8))**2).sum()
 
+# Code from Google AI
+def log_loss(y_true, y_pred, epsilon=1e-15):
+    """
+    Calculates the log loss (binary cross-entropy) between true and predicted values.
+
+    Args:
+        y_true (array-like): True labels (0 or 1).
+        y_pred (array-like): Predicted probabilities (values between 0 and 1).
+        epsilon (float, optional): A small value to prevent log(0) errors. Defaults to 1e-15.
+
+    Returns:
+        float: The calculated log loss.
+    """
+    y_true = np.asarray(y_true)
+    y_pred = np.clip(y_pred, epsilon, 1 - epsilon)
+    loss = -np.mean(y_true * np.log(y_pred) + (1 - y_true) * np.log(1 - y_pred))
+    return loss
+
 def arglist(*args, **kwargs):
     return (*args, kwargs)
 

--- a/src/vivarium_helpers/prob_distributions/sampling.py
+++ b/src/vivarium_helpers/prob_distributions/sampling.py
@@ -129,11 +129,15 @@ def sample_series_from_propensity(
         )
     if index is None and isinstance(propensity, (pd.Series, pd.DataFrame)):
         index = propensity.index
+
+    # Look for a name we can use for the returned Series
     if name is None:
         if isinstance(category_cdf, pd.DataFrame):
             name = category_cdf.columns.name
-        elif isinstance(category_cdf, pd.Series):
+        if name is None and isinstance(category_cdf, pd.Series):
             name = category_cdf.name
+        if name is None and isinstance(categories, (pd.Index, pd.Series)):
+            name = categories.name
     sampled_categories = pd.Series(
         sample_array,
         index=index,

--- a/src/vivarium_helpers/prob_distributions/sampling.py
+++ b/src/vivarium_helpers/prob_distributions/sampling.py
@@ -1,0 +1,143 @@
+import numpy as np
+import pandas as pd
+from pandas.api.types import CategoricalDtype
+
+def sample_array_from_propensity(
+    propensity,
+    categories,
+    category_cdf,
+    method='select',
+    default_category=None,
+):
+    """Sample categories using the propensities.
+    `propensity` is an array of numbers between 0 and 1.
+    `categories` is a list/1d-array-like of categories.
+    If method='select', `category_cdf` must be a mapping of categories
+    to cumulative probabilities.
+    If method='array', `category_cdf` must be an nd-array of cumulative
+    probabilities, broadcastable to shape (propensity.shape, len(categories)).
+    # TODO: check that this actually works when category_cdf has ndim != 2,
+    # and verify that I am specifying the correct shapes here.
+    """
+    if method == 'select':
+        # logger.debug(f"{categories=}")
+        # In numpy 2.0, it is necessary to have the default be
+        # of the same dtype as the other choices
+        if default_category is None:
+            if isinstance(categories, pd.Series):
+                default_category=categories.array[-1]
+            else:
+                default_category=categories[-1]
+        # If category_cdf is 1-dimensional, broadcast instead of failing
+        # when there is more than one propensity
+        # Note: If there is only 1 propensity, this makes it so its index
+        # does NOT need to be aligned with the index of a single row CDF,
+        # which may or may not be what's desired.
+        if isinstance(category_cdf, pd.DataFrame):
+            category_cdf = category_cdf.squeeze()
+        condlist = [propensity <= category_cdf[cat] for cat in categories]
+        category = np.select(condlist, choicelist=categories, default=default_category)
+    elif method == 'array':
+        if default_category is not None:
+            raise ValueError("`default_category` is unsupported with method='array'")
+        category_index = (
+            # TODO: Explain why this works...
+            np.asarray(propensity).reshape((-1,1))
+            > np.asarray(category_cdf)
+        ).sum(axis=1)
+        category = np.asarray(categories)[category_index]
+    else:
+        raise ValueError(f"Unknown method: {method}. Acceptable values are 'select' and 'array'.")
+    return category
+
+def sample_categorical_from_propensity(
+    propensity,
+    categories, # pandas CategoricalDtype or iterable of unique categories
+    category_cdf,
+    method='select',
+    default_category=None,
+    ordered=None,
+):
+    # If we know the CategoricalDtype from categories,
+    # set the `categories` and `dtype` parameters
+    # for passing into Categorical.from_codes
+    if isinstance(categories, CategoricalDtype):
+        cats = categories.categories
+        dtype = categories
+        categories = None
+    else:
+        cats = categories
+        dtype = None
+    codes = range(len(cats))
+
+    if method=='select':
+        # Need to change keys in category_cdf map from categories
+        # to codes before passing into sample_from_array
+        if isinstance(category_cdf, pd.DataFrame):
+            cat_to_code = {cat: code for cat, code in zip(cats, codes)}
+            category_cdf = category_cdf.rename(columns=cat_to_code)
+        else:
+            category_cdf = {code: category_cdf[cat] for code, cat in zip(codes, cats)}
+
+    sampled_codes = sample_array_from_propensity(
+        propensity,
+        codes,
+        category_cdf,
+        method=method,
+        default_category=default_category,
+    )
+    sampled_categories = pd.Categorical.from_codes(
+        sampled_codes, categories=categories, ordered=ordered, dtype=dtype)
+    return sampled_categories
+
+def sample_series_from_propensity(
+    propensity,
+    categories,
+    category_cdf,
+    method='select',
+    default_category=None,
+    ordered=None,
+    index=None,
+    dtype=None,
+    name=None,
+):
+    is_categorical = (
+        ordered == True
+        or isinstance(categories, CategoricalDtype)
+    )
+    if is_categorical:
+        if dtype is not None:
+            raise ValueError(
+                "`dtype` not allowed for categorical data."
+                "Pass an instance of `CategoricalDtype` to `categories` instead."
+            )
+        sample_array = sample_categorical_from_propensity(
+            propensity,
+            categories,
+            category_cdf,
+            method=method,
+            default_category=default_category,
+            ordered=ordered,
+        )
+    else:
+        sample_array = sample_array_from_propensity(
+            propensity,
+            categories,
+            category_cdf,
+            method=method,
+            default_category=default_category,
+        )
+    if index is None and isinstance(propensity, (pd.Series, pd.DataFrame)):
+        index = propensity.index
+    if name is None:
+        if isinstance(category_cdf, pd.DataFrame):
+            name = category_cdf.columns.name
+        elif isinstance(category_cdf, pd.Series):
+            name = category_cdf.name
+    sampled_categories = pd.Series(
+        sample_array,
+        index=index,
+        dtype=dtype,
+        name=name,
+    )
+    return sampled_categories


### PR DESCRIPTION
- Add the `sampling` module in the `prob_distributions` package, with code to sample the elements of a NumPy array, pandas Categorical, or pandas Series from a categorical distribution, using a fixed array of uniformly distributed "propensities" to make the random choices.
- Add a `log_loss` loss function to the `fit` module in the `prob_distributions` package.