### PR TITLE
Edits to VPH Output package for Alzheimer's simulation

### DIFF
--- a/src/vivarium_helpers/__about__.py
+++ b/src/vivarium_helpers/__about__.py
@@ -7,7 +7,7 @@ __title__ = "vivarium_helpers"
 __summary__ = "Tools maintained by the research side of the IHME simluation science team."
 __uri__ = "https://github.com/ihmeuw/vivarium_helpers"
 
-__version__ = "0.4.2"
+__version__ = "0.5.0-dev"
 
 __author__ = "Nathaniel Blair-Stahn, Beatrix Haddock"
 __email__ = "beatrixh@uw.com"

--- a/src/vivarium_helpers/utils.py
+++ b/src/vivarium_helpers/utils.py
@@ -1,6 +1,7 @@
 import collections
 import re
 import pandas as pd
+import numpy as np
 
 class FrozenAttributeMapping(collections.abc.Mapping):
     """Implementation of the Mapping abstract base class that
@@ -209,8 +210,8 @@ def constant_categorical(value, length, dtype=None):
         dtype = pd.CategoricalDtype([value])
     # Get the category code corresponding to value
     code = dtype.categories.get_loc(value)
-    # NOTE: Instead of creating a list, this could be made even more
-    # memory efficient by creating a NumPy array with an integer dtype
-    # of the minimum necessary size -- that would require computing the
-    # minimum number of bits necessary to represent the integer `length`
-    return pd.Categorical.from_codes([code] * length, dtype=dtype)
+    # NOTE: This could be made even more memory efficient by creating a
+    # NumPy array with an integer dtype of the minimum necessary size --
+    # that would require computing the minimum number of bits necessary
+    # to represent the integers 0, 1, ..., len(dtype.categories) - 1.
+    return pd.Categorical.from_codes(np.full(length, code), dtype=dtype)

--- a/src/vivarium_helpers/utils.py
+++ b/src/vivarium_helpers/utils.py
@@ -174,6 +174,24 @@ def convert_to_categorical(
     else:
         return None
 
+def constant_categorical(value, length, dtype=None):
+    """Create a pandas Categorical of the specified length with all
+    values equal to `value`. Creates the Categorical directly from codes
+    to avoid the unnecessarily large memory usage of creating a constant
+    list or Series of `value` first.
+    """
+    if dtype != 'category':
+        # If a non-categorical dtype was passed, use a dtype with a
+         # single category when creating the Categorical from codes
+        dtype = pd.CategoricalDtype([value])
+    # Get the category code corresponding to value
+    code = dtype.categories.get_loc(value)
+    # NOTE: This could be made even more memory efficient by creating a
+    # NumPy array with an integer dtype of the minimum necessary size --
+    # that would require computing the minimum number of bits necessary
+    # to represent the integers 0, 1, ..., len(dtype.categories) - 1.
+    return pd.Categorical.from_codes(np.full(length, code), dtype=dtype)
+
 def get_mean_lower_upper(described_data, colname_mapper={'mean':'mean', '2.5%':'lower', '97.5%':'upper'}):
         """
         Gets the mean, lower, and upper value from `described_data` DataFrame, which is assumed to have
@@ -203,21 +221,3 @@ def aggregate_with_join(strings, sep='|'):
 def print_memory_usage(df, label=''):
     """Print the memory usage of a dataframe in megabytes."""
     print(df.memory_usage(deep=True).sum() / 1e6, 'MB', label)
-
-def constant_categorical(value, length, dtype=None):
-    """Create a pandas Categorical of the specified length with all
-    values equal to `value`. Creates the Categorical directly from codes
-    to avoid the unnecessarily large memory usage of creating a constant
-    list or Series of `value` first.
-    """
-    if dtype != 'category':
-        # If a non-categorical dtype was passed, use a dtype with a
-         # single category when creating the Categorical from codes
-        dtype = pd.CategoricalDtype([value])
-    # Get the category code corresponding to value
-    code = dtype.categories.get_loc(value)
-    # NOTE: This could be made even more memory efficient by creating a
-    # NumPy array with an integer dtype of the minimum necessary size --
-    # that would require computing the minimum number of bits necessary
-    # to represent the integers 0, 1, ..., len(dtype.categories) - 1.
-    return pd.Categorical.from_codes(np.full(length, code), dtype=dtype)

--- a/src/vivarium_helpers/utils.py
+++ b/src/vivarium_helpers/utils.py
@@ -181,6 +181,12 @@ def get_mean_lower_upper(described_data, colname_mapper={'mean':'mean', '2.5%':'
         """
         return described_data[colname_mapper.keys()].rename(columns=colname_mapper).reset_index()
 
+def lower(x, rank=0.025):
+    return x.quantile(rank)
+
+def upper(x, rank=0.975):
+    return x.quantile(rank)
+
 # Alternative strategy to the get_mean_lower_upper function above
 def aggregate_mean_lower_upper(df_or_groupby, lower_rank=0.025, upper_rank=0.975):
     """Get mean, lower, and upper from a DataFrame or GroupBy object."""

--- a/src/vivarium_helpers/utils.py
+++ b/src/vivarium_helpers/utils.py
@@ -138,6 +138,41 @@ def column_to_ordered_categorical(
     else:
         return df.assign(**{colname: categorical})
 
+def convert_to_categorical(
+        df,
+        include_cols=(),
+        exclude_cols=(),
+        exclude_dtypes=('float', 'category'),
+        inplace=False
+    ):
+    """Convert all columns to pandas Categoricals except those with
+    dtypes listed in `exclude_dtypes` (default 'float' and 'category')
+    or those with names listed in `exclude_cols`. One can force a
+    specific column to be converted, even it its dtype is listed in
+    `exclude_dtypes`, by passing the column name to `include_cols`. It
+    is not allowed to pass a column name both to `include_cols` and
+    `exclude_cols`. Dtype conversion is performed in place if
+    `inplace=True`.
+
+    This method can save lots of memory, allowing loading and
+    manipulating larger DataFrames.
+    """
+    if  len(set(include_cols).intersection(exclude_cols)) != 0:
+        raise ValueError("A column can't be both included and excluded!")
+    if not inplace:
+        df = df.copy()
+    for col in df:
+        if (
+            col in include_cols
+            or (col not in exclude_cols
+                and df[col].dtype not in exclude_dtypes)
+        ):
+            df[col] = df[col].astype('category')
+    if not inplace:
+        return df
+    else:
+        return None
+
 def get_mean_lower_upper(described_data, colname_mapper={'mean':'mean', '2.5%':'lower', '97.5%':'upper'}):
         """
         Gets the mean, lower, and upper value from `described_data` DataFrame, which is assumed to have

--- a/src/vivarium_helpers/utils.py
+++ b/src/vivarium_helpers/utils.py
@@ -168,16 +168,12 @@ def constant_categorical(value, length, dtype=None):
     to avoid the unnecessarily large memory usage of creating a constant
     list or Series of `value` first.
     """
-    if dtype == 'category':
-        # Get the category code corresponding to value
-        code = dtype.categories.get_loc(value)
-    else:
-        # We'll create a Categorical with a single category, so the only
-        # code will be 0
-        code = 0
-         # If a non-categorical dtype was passed, set dtype to None when
-         # creating the Categorical from codes
-        dtype = None
+    if dtype != 'category':
+        # If a non-categorical dtype was passed, use a dtype with a
+         # single category when creating the Categorical from codes
+        dtype = pd.CategoricalDtype([value])
+    # Get the category code corresponding to value
+    code = dtype.categories.get_loc(value)
     # NOTE: Instead of creating a list, this could be made even more
     # memory efficient by creating a NumPy array with an integer dtype
     # of the minimum necessary size -- that would require computing the

--- a/src/vivarium_helpers/utils.py
+++ b/src/vivarium_helpers/utils.py
@@ -157,3 +157,29 @@ def aggregate_with_join(strings, sep='|'):
     sep.join(strings).
     """
     return sep.join(strings)
+
+def print_memory_usage(df, label=''):
+    """Print the memory usage of a dataframe in megabytes."""
+    print(df.memory_usage(deep=True).sum() / 1e6, 'MB', label)
+
+def constant_categorical(value, length, dtype=None):
+    """Create a pandas Categorical of the specified length with all
+    values equal to `value`. Creates the Categorical directly from codes
+    to avoid the unnecessarily large memory usage of creating a constant
+    list or Series of `value` first.
+    """
+    if dtype == 'category':
+        # Get the category code corresponding to value
+        code = dtype.categories.get_loc(value)
+    else:
+        # We'll create a Categorical with a single category, so the only
+        # code will be 0
+        code = 0
+         # If a non-categorical dtype was passed, set dtype to None when
+         # creating the Categorical from codes
+        dtype = None
+    # NOTE: Instead of creating a list, this could be made even more
+    # memory efficient by creating a NumPy array with an integer dtype
+    # of the minimum necessary size -- that would require computing the
+    # minimum number of bits necessary to represent the integer `length`
+    return pd.Categorical.from_codes([code] * length, dtype=dtype)

--- a/src/vivarium_helpers/vph_output/cleaning.py
+++ b/src/vivarium_helpers/vph_output/cleaning.py
@@ -24,7 +24,7 @@ def split_measure_and_transition_columns(transition_df):
             .assign(measure='transition_count') # Name the measure 'transition_count' rather than 'event_count'
            )
 
-def extract_transition_states(transition_df):
+def extract_transition_states(transition_df, transition_name_col='transition'):
     """Gets the 'from state' and 'to state' from the transitions in a transition count dataframe,
     after the transition has been put in its own 'transition' column by the `split_measure_and_transition_columns`
     function.
@@ -33,7 +33,7 @@ def extract_transition_states(transition_df):
     # Renaming the 'susceptible_to' states is a hack to deal with the fact there's not a unique string
     # separating the 'from' and 'to' states -- it should be '__to__' instead of '_to_' or something
     states_df = (
-        transition_df['transition']
+        transition_df[transition_name_col]
         .str.replace("susceptible_to", "without") # Remove word 'to' from all states so we can split transitions on '_to_'
         .str.extract(states_from_transition_pattern) # Create dataframe with 'from_state' and 'to_state' columns
         .apply(lambda col: col.str.replace("without", "susceptible_to")) # Restore original state names

--- a/src/vivarium_helpers/vph_output/measures.py
+++ b/src/vivarium_helpers/vph_output/measures.py
@@ -15,6 +15,7 @@ class VPHResults(VPHOutput):
         draw_col=None,
         scenario_col=None,
         measure_col=None,
+        location_col: str|bool=False,
         index_cols=None,
         # record_dalys=True,
         **kwargs,
@@ -25,7 +26,8 @@ class VPHResults(VPHOutput):
             draw_col,
             scenario_col,
             measure_col,
-            index_cols
+            location_col,
+            index_cols,
         )
         self._clean_vph_output()
         # if record_dalys:

--- a/src/vivarium_helpers/vph_output/measures.py
+++ b/src/vivarium_helpers/vph_output/measures.py
@@ -107,12 +107,16 @@ class VPHResults(VPHOutput):
         if 'dalys' in measures and 'dalys' not in table_names:
             ylls = burden.query("measure == 'ylls'")
             ylds = burden.query("measure == 'ylds'")
+            # FIXME: Define the cause column somewhere else that makes
+            # sense, and deal with different column names in older
+            # Vivarium models
+            cause_col = 'entity' # Used to be 'cause'
             # If we have comorbidity-adjusted all-cause YLDs, ensure
             # that we also have all-cause YLLs so all-cause DALYs will
             # be correct
-            if 'all_causes' in np.setdiff1d(ylds['cause'], ylls['cause']):
+            if 'all_causes' in np.setdiff1d(ylds[cause_col], ylls[cause_col]):
                 all_cause_ylls = self.ops.marginalize(
-                    ylls.assign(cause='all_causes'), [])
+                    ylls.assign(**{cause_col: 'all_causes'}), [])
                 burden = pd.concat([burden, all_cause_ylls])
                 # print('yll causes:', ylls.cause.unique())
             burden = self.ops.aggregate_categories(

--- a/src/vivarium_helpers/vph_output/measures.py
+++ b/src/vivarium_helpers/vph_output/measures.py
@@ -10,6 +10,7 @@ class VPHResults(VPHOutput):
         self,
         mapping=(),
         /,
+        ops: VPHOperator|None = None,
         value_col=None,
         draw_col=None,
         scenario_col=None,
@@ -19,7 +20,7 @@ class VPHResults(VPHOutput):
         **kwargs,
     ):
         super().__init__(mapping, **kwargs)
-        self.ops = VPHOperator(
+        self.ops = ops or VPHOperator(
             value_col,
             draw_col,
             scenario_col,

--- a/src/vivarium_helpers/vph_output/operations.py
+++ b/src/vivarium_helpers/vph_output/operations.py
@@ -552,13 +552,13 @@ class VPHOperator:
         # Add the identifier column to the index of the larger dataframe
         # (or default to the subtrahend dataframe if neither needs broadcasting).
         if minuend_id is None:
-            # Broadcast minuend over minuend
+            # Broadcast subtrahend over minuend
             minuend.set_index(identifier_col, append=True, inplace=True)
             # Explicit reindexing is necessary to preserve Categoricals
             # in the index when broadcasting
             subtrahend = subtrahend.reindex(minuend.index)
         else:
-            # Broadcast subtrahend over subtrahend (or no broadcasting necessary)
+            # Broadcast minuend over subtrahend (or no broadcasting necessary)
             subtrahend.set_index(identifier_col, append=True, inplace=True)
             # Explicit reindexing is necessary to preserve Categoricals
             # in the index when broadcasting

--- a/src/vivarium_helpers/vph_output/operations.py
+++ b/src/vivarium_helpers/vph_output/operations.py
@@ -302,9 +302,9 @@ class VPHOperator:
         numerator: pd.DataFrame,
         denominator: pd.DataFrame,
         strata,
-        prefilter_query=None,
         numerator_broadcast=None,
         denominator_broadcast=None,
+        prefilter_query=None,
         multiplier=1,
         value_col=None,
         index_cols=None,
@@ -327,13 +327,6 @@ class VPHOperator:
 
         strata : list of column names present in the numerator and denominator (also accepts a single column name)
             The stratification variables for the ratio or rate.
-
-        prefilter_query : str or None, default None
-            A query string to pass to DataFrame.query() for both the
-            numerator and denominator before taking the ratio. This is
-            useful if you're interested in computing a ratio for a
-            subset of the full population (e.g., only certain age
-            groups).
 
         multiplier : int or float, default 1
             Multiplier for the numerator, typically a power of 10,
@@ -362,6 +355,13 @@ class VPHOperator:
 
         denominator_broadcast : list of column names present in the denominator, or None
             Additional columns in the numerator by which to broadcast.
+
+        prefilter_query : str or None, default None
+            A query string to pass to DataFrame.query() for both the
+            numerator and denominator before taking the ratio. This is
+            useful if you're interested in computing a ratio for a
+            subset of the full population (e.g., only certain age
+            groups).
 
         value_col : single column name (a singleton list is also accepted), default VALUE_COLUMN
             The column where the values in the numerator and denominator dataframes are stored.

--- a/src/vivarium_helpers/vph_output/operations.py
+++ b/src/vivarium_helpers/vph_output/operations.py
@@ -409,6 +409,10 @@ class VPHOperator:
             # Really I think the 'measure' column should always have a
             # unique value, but currently that is not the case for
             # transition counts...
+            # TODO: Would it make sense to instead rename these columns
+            # 'numerator_measure' and 'denominator_measure' and add them
+            # to the numerator_broadcast and denominator_broadcast,
+            # respectively? I don't remember whether I've tried that...
             numerator_measure = '|'.join(numerator[measure_col].unique())
             denominator_measure = '|'.join(denominator[measure_col].unique())
 
@@ -439,8 +443,10 @@ class VPHOperator:
             ratio = ratio.dropna()
 
         if record_inputs:
-            ratio[f'numerator_{measure_col}'] = numerator_measure
-            ratio[f'denominator_{measure_col}'] = denominator_measure
+            ratio[f'numerator_{measure_col}'] = constant_categorical(
+                numerator_measure, len(ratio))
+            ratio[f'denominator_{measure_col}'] = constant_categorical(
+                denominator_measure, len(ratio))
             ratio['multiplier'] = multiplier
 
         if reset_index:

--- a/src/vivarium_helpers/vph_output/operations.py
+++ b/src/vivarium_helpers/vph_output/operations.py
@@ -35,22 +35,21 @@ class VPHOperator:
             SCENARIO_COLUMN if scenario_col is None else scenario_col)
         self.measure_col = (
             MEASURE_COLUMN if measure_col is None else measure_col)
-        if index_cols is not None:
+        self.index_cols = (
+            [self.draw_col, self.scenario_col] if index_cols is None
             # Make a copy of index columns to avoid mutating something
             # we shouldn't
-            self.index_cols = [*_ensure_iterable(index_cols)]
-        else:
-            self.index_cols = [self.draw_col, self.scenario_col]
-            match location_col:
-                case False:
-                    # location column is not in the index
-                    pass
-                case True:
-                    # Add default location column to index
-                    self.index_cols.append(LOCATION_COLUMN)
-                case _:
-                    # Add specified location column to the index
-                    self.index_cols.append(location_col)
+            else [*_ensure_iterable(index_cols)])
+        if location_col is True:
+            # Set location column to the default
+            location_col = LOCATION_COLUMN
+        if location_col is not False:
+            # If location column is valid, add it to the index
+            if location_col in self.index_cols:
+                raise ValueError(
+                    "Index columns already contain location column")
+            else:
+                self.index_cols.append(location_col)
 
     def set_index_columns(self, index_columns:list)->None:
         """

--- a/src/vivarium_helpers/vph_output/operations.py
+++ b/src/vivarium_helpers/vph_output/operations.py
@@ -5,10 +5,14 @@ from ..utils import (
     print_memory_usage, constant_categorical
 )
 
+# TODO: Maybe put column names in an Enum
 VALUE_COLUMN = 'value'
 DRAW_COLUMN  = 'input_draw'
 SCENARIO_COLUMN = 'scenario'
 MEASURE_COLUMN = 'measure'
+# FIXME: location column should be accessible in loading.py as well --
+# maybe I need to put column names in a separate module
+LOCATION_COLUMN = 'location'
 
 INDEX_COLUMNS = [DRAW_COLUMN, SCENARIO_COLUMN]
 
@@ -22,6 +26,7 @@ class VPHOperator:
         draw_col=None,
         scenario_col=None,
         measure_col=None,
+        location_col: str|bool=False,
         index_cols=None
     ):
         self.value_col = VALUE_COLUMN if value_col is None else value_col
@@ -30,9 +35,22 @@ class VPHOperator:
             SCENARIO_COLUMN if scenario_col is None else scenario_col)
         self.measure_col = (
             MEASURE_COLUMN if measure_col is None else measure_col)
-        self.index_cols = (
-            [self.draw_col, self.scenario_col] if index_cols is None
-            else index_cols)
+        if index_cols is not None:
+            # Make a copy of index columns to avoid mutating something
+            # we shouldn't
+            self.index_cols = [*_ensure_iterable(index_cols)]
+        else:
+            self.index_cols = [self.draw_col, self.scenario_col]
+            match location_col:
+                case True:
+                    # Add default location column to index
+                    self.index_cols.append(LOCATION_COLUMN)
+                case False:
+                    # location column is not in the index
+                    pass
+                case _:
+                    # Add specified location column to the index
+                    self.index_cols.append(location_col)
 
     def set_index_columns(self, index_columns:list)->None:
         """

--- a/src/vivarium_helpers/vph_output/operations.py
+++ b/src/vivarium_helpers/vph_output/operations.py
@@ -42,12 +42,12 @@ class VPHOperator:
         else:
             self.index_cols = [self.draw_col, self.scenario_col]
             match location_col:
-                case True:
-                    # Add default location column to index
-                    self.index_cols.append(LOCATION_COLUMN)
                 case False:
                     # location column is not in the index
                     pass
+                case True:
+                    # Add default location column to index
+                    self.index_cols.append(LOCATION_COLUMN)
                 case _:
                     # Add specified location column to the index
                     self.index_cols.append(location_col)
@@ -327,8 +327,9 @@ class VPHOperator:
         value_col=None,
         index_cols=None,
         measure_col=None,
-        dropna=False,
+        measure=None,
         record_inputs=None,
+        dropna=False,
         reset_index=True,
     )-> pd.DataFrame:
         """
@@ -388,14 +389,17 @@ class VPHOperator:
             The column indicating the type of measure stored in the numerator and denominator dataframes.
             Not used if `record_inputs` is False.
 
-        dropna : boolean, default False
-             Whether to drop rows with NaN values in the result, namely
-             if division by 0 occurs because of an empty stratum in the denominator.
+        measure: str or None, default None
+            A measure to assign to the measure column of this ratio.
 
         record_inputs : boolean or None, default None
             Whether to record the multiplier and the numeraor's and denominator's measures in the output.
             If None, defaults to the value of `reset_index` to facilitate performing further operations with
             the ratio if reset_index == False.
+
+        dropna : boolean, default False
+             Whether to drop rows with NaN values in the result, namely
+             if division by 0 occurs because of an empty stratum in the denominator.
 
         reset_index : boolean, default True
             Whether to move index levels back into the dataframe's columns after computing the ratio.
@@ -471,6 +475,10 @@ class VPHOperator:
             # Note: inplace=True is deprecated because .dropna() changes
             # the shape of data and never actually operates in place
             ratio = ratio.dropna()
+
+        # Record specified measure in measure column
+        if measure is not None:
+            ratio[measure_col] = constant_categorical(measure, len(ratio))
 
         if record_inputs:
             ratio[f'numerator_{measure_col}'] = constant_categorical(

--- a/src/vivarium_helpers/vph_output/operations.py
+++ b/src/vivarium_helpers/vph_output/operations.py
@@ -302,9 +302,10 @@ class VPHOperator:
         numerator: pd.DataFrame,
         denominator: pd.DataFrame,
         strata,
-        multiplier=1,
+        prefilter_query=None,
         numerator_broadcast=None,
         denominator_broadcast=None,
+        multiplier=1,
         value_col=None,
         index_cols=None,
         measure_col=None,
@@ -326,6 +327,13 @@ class VPHOperator:
 
         strata : list of column names present in the numerator and denominator (also accepts a single column name)
             The stratification variables for the ratio or rate.
+
+        prefilter_query : str or None, default None
+            A query string to pass to DataFrame.query() for both the
+            numerator and denominator before taking the ratio. This is
+            useful if you're interested in computing a ratio for a
+            subset of the full population (e.g., only certain age
+            groups).
 
         multiplier : int or float, default 1
             Multiplier for the numerator, typically a power of 10,
@@ -386,6 +394,10 @@ class VPHOperator:
             value_col = self.value_col
         if measure_col is None:
             measure_col = self.measure_col
+        # Filter both the numerator and denominator if requested
+        if prefilter_query is not None:
+            numerator = numerator.query(prefilter_query)
+            denominator = denominator.query(prefilter_query)
         # Ensure that index columns in numerator and denominator are columns not index levels,
         # to guarantee that _ensure_iterable will work and df[measure_col] will work.
         numerator = _ensure_columns_not_levels(numerator)


### PR DESCRIPTION
Adds some functionality to handle outputs from the Alzheimer's simulation. Much of the additions are for better handling pandas Categoricals, which was necessary for loading some large DataFrames into memory. Other changes are updating column names and adding parameters to functions to make them more flexible.

- Add some functions in `utils.py` for dealing with Categoricals and printing memory usage
- Add explicit reindexing to the `difference` function to preserve Categoricals and save memory
- Update hard-coded column names in the `extract_transition_states` and `get_burden` functions
- Add `prefilter_query` and `measure` parameters to the `ratio` function
- Add a `location_col` parameter to the `VPHOperator` constructor, and add `location_col` and `ops` parameters to the `VPHResults` constructor
- Generalize the `describe` function to a `summarize_draws` function which defaults to computing "mean, lower, upper"